### PR TITLE
Add skip migration option to installer

### DIFF
--- a/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
@@ -4,6 +4,7 @@ module SolidusPaypalCommercePlatform
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :auto_run_migrations, type: :boolean, default: false
+      class_option :skip_migrations, type: :boolean, default: false
 
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_paypal_commerce_platform\n" # rubocop:disable Layout/LineLength
@@ -26,6 +27,8 @@ module SolidusPaypalCommercePlatform
       end
 
       def run_migrations
+        return if options[:skip_migrations]
+
         run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]')) # rubocop:disable Layout/LineLength
         if run_migrations
           run 'bin/rails db:migrate'


### PR DESCRIPTION
When the user installs this extension as part of the initial Solidus
install, we don't want to ask them if they want to migrate - in fact,
we'd like to skip migration entirely until the final migration happens
as part of the apps setup. This option allows for that!