### PR TITLE
Set current_order_id and token during payment step

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -5,6 +5,8 @@
 <input type="hidden" name="payment_source[<%= payment_method.id %>][paypal_email]" id="payments_source_paypal_email">
 
 <script>
+  Spree.current_order_id = "<%= @order.number %>"
+  Spree.current_order_token = "<%= @order.guest_token %>"
   $( document ).ready(function() {
     SolidusPaypalCommercePlatform.renderButton("<%= payment_method.id %>",<%= raw payment_method.button_style.to_json %>)
   })


### PR DESCRIPTION
After successfully installing the gem and adding the new payment method (configuring it to use the static_preferences), we tried to checkout but got a 401 error. It turned out this stemmed from the current_order_token not being set during the payment step of checkout. The specific error was:
`solidus_paypal_commerce_platform/paypal_orders/undefined?payment_method_id=5 401(Unauthorized)`

Here's a screenshot: https://monosnap.com/file/BiEABBcYDBZRn6pwA2i4vWzr6yMkil

This error was fixed by setting `current_order_token` in the view partial. For good measure, we decided to also set `current_order_id`. Checkout is now working.