### PR TITLE
Add partner ID attribute to SDK javascript tag

### DIFF
--- a/lib/solidus_paypal_commerce_platform/client.rb
+++ b/lib/solidus_paypal_commerce_platform/client.rb
@@ -10,7 +10,7 @@ module SolidusPaypalCommercePlatform
     SUCCESS_STATUS_CODES = [201, 204].freeze
 
     PARTNER_ATTRIBUTION_INJECTOR = ->(request) {
-      request.headers["PayPal-Partner-Attribution-Id"] = "Solidus_PCP_SP"
+      request.headers["PayPal-Partner-Attribution-Id"] = SolidusPaypalCommercePlatform.config.partner_code
     }.freeze
 
     attr_reader :environment

--- a/lib/solidus_paypal_commerce_platform/configuration.rb
+++ b/lib/solidus_paypal_commerce_platform/configuration.rb
@@ -66,5 +66,9 @@ module SolidusPaypalCommercePlatform
     def partner_client_id
       @partner_client_id ||= ENV['PAYPAL_PARTNER_CLIENT_ID'] || DEFAULT_PARTNER_CLIENT_ID[env.to_sym]
     end
+
+    def partner_code
+      "Solidus_PCP_SP"
+    end
   end
 end

--- a/lib/views/frontend/solidus_paypal_commerce_platform/shared/_javascript_sdk_tag.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/shared/_javascript_sdk_tag.html.erb
@@ -1,0 +1,4 @@
+<script 
+  src="<%= payment_method.javascript_sdk_url(order: @order) %>" 
+  data-partner-attribution-id="<%= SolidusPaypalCommercePlatform.config.partner_code %>">
+</script>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -1,4 +1,4 @@
-<script src="<%= payment_method.javascript_sdk_url(order: @order) %>"></script>
+<%= render partial: "solidus_paypal_commerce_platform/shared/javascript_sdk_tag", locals: {payment_method: payment_method} %>
 
 <div id="paypal-button-container"></div>
 

--- a/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
@@ -1,6 +1,5 @@
 <div style="margin-left:auto;margin-right:auto;width:50%;margin-top:20px;">
-  <script src="<%= payment_method.javascript_sdk_url(order: @order) %>">
-  </script>
+  <%= render partial: "solidus_paypal_commerce_platform/shared/javascript_sdk_tag", locals: {payment_method: payment_method} %>
 
   <div id="paypal-button-container"></div>
 

--- a/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
@@ -1,6 +1,5 @@
 <div style="margin-top:20px;">
-  <script src="<%= payment_method.javascript_sdk_url %>">
-  </script>
+  <%= render partial: "solidus_paypal_commerce_platform/shared/javascript_sdk_tag", locals: {payment_method: payment_method} %>
 
   <div id="paypal-button-container"></div>
 

--- a/spec/features/frontend/cart_spec.rb
+++ b/spec/features/frontend/cart_spec.rb
@@ -16,22 +16,24 @@ RSpec.describe "Cart page" do
       )
     end
 
-    def paypal_script_options
-      script_tag_url = URI(page.find('script[src*="sdk/js?"]', visible: false)[:src])
-      script_tag_url.query.split('&')
-    end
-
-    it "generate a js file with the correct credentials and intent attached" do
-      visit '/cart'
-      expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
-    end
-
-    context "when auto-capture is set to true" do
-      it "generate a js file with intent capture" do
-        paypal_payment_method.update(auto_capture: true)
+    context "when generating a script tag" do
+      it "generates a url with the correct credentials attached" do
         visit '/cart'
-        expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
-        expect(paypal_script_options).to include("intent=capture")
+        expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+      end
+
+      it "generates a partner_id attribute with the correct partner code attached" do
+        visit '/cart'
+        expect(js_sdk_script_partner_id).to eq("Solidus_PCP_SP")
+      end
+
+      context "when auto-capture is set to true" do
+        it "generates a url with intent capture" do
+          paypal_payment_method.update(auto_capture: true)
+          visit '/cart'
+          expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+          expect(js_sdk_script_query).to include("intent=capture")
+        end
       end
     end
   end

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -17,22 +17,24 @@ RSpec.describe "Checkout" do
       )
     end
 
-    def paypal_script_options
-      script_tag_url = URI(page.find('script[src*="sdk/js?"]', visible: false)[:src])
-      script_tag_url.query.split('&')
-    end
-
-    it "generates a js file with the correct credentials and intent attached" do
-      visit '/checkout/payment'
-      expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
-    end
-
-    context "when auto-capture is set to true" do
-      it "generates a js file with intent capture" do
-        paypal_payment_method.update(auto_capture: true)
+    context "when generating a script tag" do
+      it "generates a url with the correct credentials attached" do
         visit '/checkout/payment'
-        expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
-        expect(paypal_script_options).to include("intent=capture")
+        expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+      end
+
+      it "generates a partner_id attribute with the correct partner code attached" do
+        visit '/checkout/payment'
+        expect(js_sdk_script_partner_id).to eq("Solidus_PCP_SP")
+      end
+
+      context "when auto-capture is set to true" do
+        it "generates a url with intent capture" do
+          paypal_payment_method.update(auto_capture: true)
+          visit '/checkout/payment'
+          expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+          expect(js_sdk_script_query).to include("intent=capture")
+        end
       end
     end
 

--- a/spec/features/frontend/product_spec.rb
+++ b/spec/features/frontend/product_spec.rb
@@ -12,22 +12,24 @@ RSpec.describe "Product page", js: true do
       paypal_payment_method
     end
 
-    def paypal_script_options
-      script_tag_url = URI(page.find('script[src*="sdk/js?"]', visible: false)[:src])
-      script_tag_url.query.split('&')
-    end
-
-    it "generates a js file with the correct credentials and intent attached" do
-      visit "/products/#{product.slug}"
-      expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
-    end
-
-    context "when auto-capture is set to true" do
-      it "generates a js file with intent capture" do
-        paypal_payment_method.update(auto_capture: true)
+    context "when generating a script tag" do
+      it "generates a url with the correct credentials attached" do
         visit "/products/#{product.slug}"
-        expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
-        expect(paypal_script_options).to include("intent=capture")
+        expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+      end
+
+      it "generates a partner_id attribute with the correct partner code attached" do
+        visit "/products/#{product.slug}"
+        expect(js_sdk_script_partner_id).to eq("Solidus_PCP_SP")
+      end
+
+      context "when auto-capture is set to true" do
+        it "generates a url with intent capture" do
+          paypal_payment_method.update(auto_capture: true)
+          visit "/products/#{product.slug}"
+          expect(js_sdk_script_query).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+          expect(js_sdk_script_query).to include("intent=capture")
+        end
       end
     end
 

--- a/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
+++ b/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
@@ -82,4 +82,10 @@ RSpec.describe SolidusPaypalCommercePlatform::Configuration do
       expect(subject.state_guesser_class).to eq(SolidusPaypalCommercePlatform::BetterStateGuesser)
     end
   end
+
+  describe "#partner_code" do
+    it "returns the correct code" do
+      expect(subject.partner_code).to eq("Solidus_PCP_SP")
+    end
+  end
 end

--- a/spec/support/paypal_sdk_script_tag_helper.rb
+++ b/spec/support/paypal_sdk_script_tag_helper.rb
@@ -1,0 +1,13 @@
+module PaypalSdkScriptTagHelper
+  def js_sdk_script_query
+    URI(page.find('script[src*="sdk/js?"]', visible: false)[:src]).query.split('&')
+  end
+
+  def js_sdk_script_partner_id
+    page.find('script[src*="sdk/js?"]', visible: false)['data-partner-attribution-id']
+  end
+end
+
+RSpec.configure do |config|
+  config.include PaypalSdkScriptTagHelper, type: :feature
+end


### PR DESCRIPTION
Separates the javascript sdk tag into it's own partial, and adds the
partner attribution ID attribute requested by PayPal. Also adds tests
to ensure this attribute is there, and slightly jostles the test
contexts to make a bit more sense. Handles part 1 of #99 