### PR TITLE
Add PayPal messaging component

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -11,6 +11,7 @@ module SolidusPaypalCommercePlatform
     preference :paypal_button_layout, :paypal_select, default: "vertical"
     preference :display_on_cart, :boolean, default: true
     preference :display_on_product_page, :boolean, default: true
+    preference :display_credit_messaging, :boolean, default: true
 
     def partial_name
       "paypal_commerce_platform"
@@ -67,6 +68,7 @@ module SolidusPaypalCommercePlatform
         'client-id': client_id,
         intent: auto_capture ? "capture" : "authorize",
         commit: commit_immediately ? "false" : "true",
+        components: options[:display_credit_messaging] ? "buttons,messages" : "buttons",
       }
 
       "https://www.paypal.com/sdk/js?#{parameters.to_query}"

--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -1,6 +1,9 @@
 <script src="<%= payment_method.javascript_sdk_url(order: @order) %>"></script>
 
 <div id="paypal-button-container"></div>
+
+<div data-pp-message data-pp-placement="payment" data-pp-amount="<%= @order.total %>"></div>
+
 <input type="hidden" name="payment_source[<%= payment_method.id %>][paypal_order_id]" id="payments_source_paypal_order_id">
 <input type="hidden" name="payment_source[<%= payment_method.id %>][paypal_email]" id="payments_source_paypal_email">
 

--- a/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
@@ -4,6 +4,8 @@
 
   <div id="paypal-button-container"></div>
 
+  <div data-pp-message data-pp-placement="cart" data-pp-amount="<%= @order.total %>"></div>
+
   <script>
     Spree.current_order_id = "<%= @order.number %>"
     Spree.current_order_token = "<%= @order.guest_token %>"

--- a/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
@@ -4,6 +4,8 @@
 
   <div id="paypal-button-container"></div>
 
+  <div data-pp-message data-pp-placement="product" data-pp-amount="<%= @product.price %>"></div>
+
   <script>
     SolidusPaypalCommercePlatform.checkout_url = "<%= checkout_url %>"
     $( document ).ready(function() {

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -92,6 +92,25 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
         expect(url.query.split("&")).to include("commit=true")
       end
     end
+
+    context 'when messaging is turned on' do
+      let(:order) { instance_double(Spree::Order, checkout_steps: { "foo" => "bar" }) }
+
+      it 'includes messaging component' do
+        paypal_payment_method.preferences.update(display_credit_messaging: true)
+        expect(url.query.split("&")).to include("components=buttons%2Cmessages")
+      end
+    end
+
+    context 'when messaging is turned off' do
+      let(:order) { instance_double(Spree::Order, checkout_steps: { "foo" => "bar" }) }
+
+      it 'only includes buttons components' do
+        paypal_payment_method.preferences.update(display_credit_messaging: false)
+        expect(url.query.split("&")).not_to include("messages")
+        expect(url.query.split("&")).to include("components=buttons")
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Adds messaging component for PayPal, which displays various PayPal
credit messaging like "Buy now and pay in 4 installments of $#{amount}"

Also adds a preference for whether or not to display this messaging.

Part 2 of #99 

![unnamed](https://user-images.githubusercontent.com/5720486/95253759-7b72ef80-07e4-11eb-9a85-3bd4a43b0994.png)
