### PR TITLE
Add address only to initial PayPal request

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/paypal_order.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_order.rb
@@ -18,7 +18,7 @@ module SolidusPaypalCommercePlatform
       {
         op: 'replace',
         path: '/purchase_units/@reference_id==\'default\'',
-        value: purchase_units[0]
+        value: purchase_units(include_shipping_address: false)[0]
       }
     end
 
@@ -50,12 +50,12 @@ module SolidusPaypalCommercePlatform
       }
     end
 
-    def purchase_units
+    def purchase_units(include_shipping_address: true)
       [
         {
           amount: amount,
           items: line_items,
-          shipping: (shipping_info if @order.ship_address)
+          shipping: (shipping_info if @order.ship_address && include_shipping_address)
         }
       ]
     end

--- a/spec/requests/solidus_paypal_commerce_platform/shipping_rates_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/shipping_rates_controller_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe SolidusPaypalCommercePlatform::ShippingRatesController, type: :re
       }
     end
 
-    it "returns a paypal_order with the new address" do
-      expect(response.body).to include new_address.state.abbr
-      expect(response.body).not_to include order.ship_address.state.abbr
+    it "returns a paypal_order without the simulated address" do
+      expect(response.body).not_to include "admin_area_1\":\"#{new_address.state.abbr}\""
+      expect(response.body).not_to include "admin_area_1\":\"#{order.ship_address.state.abbr}\""
     end
 
     it "does not modify original address" do


### PR DESCRIPTION
The ship address changes to a "fake" address for shipping simulation
requests, this "fake" address should not be sent back to PayPal, or
they will - in some cases - display this fake address to the user.

Ref #104 