### PR TITLE
Add currency to PayPal SDK URL

### DIFF
--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -11,7 +11,8 @@ module SolidusPaypalCommercePlatform
 
       @order = ::Spree::Order.create!(
         user: try_spree_current_user,
-        store: current_store
+        store: current_store,
+        currency: current_pricing_options.currency
       )
 
       if @order.contents.update_cart order_params

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -58,7 +58,7 @@ module SolidusPaypalCommercePlatform
       }
     end
 
-    def javascript_sdk_url(order: nil)
+    def javascript_sdk_url(order: nil, currency: nil)
       # Both instance and class respond to checkout_steps.
       step_names = order ? order.checkout_steps : ::Spree::Order.checkout_steps.keys
 
@@ -69,6 +69,7 @@ module SolidusPaypalCommercePlatform
         intent: auto_capture ? "capture" : "authorize",
         commit: commit_immediately ? "false" : "true",
         components: options[:display_credit_messaging] ? "buttons,messages" : "buttons",
+        currency: currency
       }
 
       "https://www.paypal.com/sdk/js?#{parameters.to_query}"

--- a/lib/views/frontend/solidus_paypal_commerce_platform/shared/_javascript_sdk_tag.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/shared/_javascript_sdk_tag.html.erb
@@ -1,4 +1,6 @@
+<% currency = @order ? @order.currency : current_pricing_options.currency %>
+
 <script 
-  src="<%= payment_method.javascript_sdk_url(order: @order) %>" 
+  src="<%= payment_method.javascript_sdk_url(order: @order, currency: currency) %>" 
   data-partner-attribution-id="<%= SolidusPaypalCommercePlatform.config.partner_code %>">
 </script>

--- a/spec/features/frontend/cart_spec.rb
+++ b/spec/features/frontend/cart_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe "Cart page" do
         expect(js_sdk_script_partner_id).to eq("Solidus_PCP_SP")
       end
 
+      it "generates a URL with the correct currency" do
+        allow(order).to receive(:currency).and_return "EUR"
+        visit '/cart'
+        expect(js_sdk_script_query).to include("currency=EUR")
+      end
+
       context "when auto-capture is set to true" do
         it "generates a url with intent capture" do
           paypal_payment_method.update(auto_capture: true)

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe "Checkout" do
         expect(js_sdk_script_partner_id).to eq("Solidus_PCP_SP")
       end
 
+      it "generates a URL with the correct currency" do
+        allow(order).to receive(:currency).and_return "EUR"
+        visit '/checkout/payment'
+        expect(js_sdk_script_query).to include("currency=EUR")
+      end
+
       context "when auto-capture is set to true" do
         it "generates a url with intent capture" do
           paypal_payment_method.update(auto_capture: true)

--- a/spec/features/frontend/product_spec.rb
+++ b/spec/features/frontend/product_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "Product page", js: true do
         expect(js_sdk_script_partner_id).to eq("Solidus_PCP_SP")
       end
 
+      it "generates a URL with the correct currency" do
+        allow_any_instance_of(SolidusPaypalCommercePlatform::PricingOptions).to receive(:currency).and_return "EUR"
+        visit "/products/#{product.slug}"
+        expect(js_sdk_script_query).to include("currency=EUR")
+      end
+
       context "when auto-capture is set to true" do
         it "generates a url with intent capture" do
           paypal_payment_method.update(auto_capture: true)


### PR DESCRIPTION
Adds a currency to the PayPal SDK URL, which is necessary when the
currency is not USD. Otherwise, PayPal will throw an error and checkout
will be aborted.

Also makes our order creation process respect the current pricing
options.

closes #107 