### PR TITLE
Constrain solidus_support to 0.5.1 or greater

### DIFF
--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deface', '~> 1.5'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.5'
+  spec.add_dependency 'solidus_support', [">= 0.5.1", "< 1"]
   spec.add_dependency 'solidus_webhooks', '~> 0.2.0'
 
   spec.add_dependency 'paypal-checkout-sdk'


### PR DESCRIPTION
This extension doesn't work with `0.5` due to an issue with decorator loading - we have to use `0.5.1` or greater.