### PR TITLE
Relax SolidusWebhooks dependency

### DIFF
--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deface', '~> 1.5'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', [">= 0.5.1", "< 1"]
-  spec.add_dependency 'solidus_webhooks', '~> 0.2.0'
+  spec.add_dependency 'solidus_webhooks', '~> 0.2'
 
   spec.add_dependency 'paypal-checkout-sdk'
 


### PR DESCRIPTION
There's no need to block it at 0.2.x.