### PR TITLE
Update extension for Solidus 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,10 @@ RSpec/VerifiedDoubles:
   # Sometimes you really need an "anything" double
   IgnoreSymbolicNames: true
 
+Rspec/Naming/VariableNumber:
+  # PayPal uses snake_case, we use normal_case ¯\_(ツ)_/¯
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Exclude:
     - spec/**/*

--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deface', '~> 1.5'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', [">= 0.5.1", "< 1"]
+  spec.add_dependency 'solidus_support', [">= 0.8.0", "< 1"]
   spec.add_dependency 'solidus_webhooks', '~> 0.2'
 
   spec.add_dependency 'paypal-checkout-sdk'

--- a/spec/models/solidus_paypal_commerce_platform/paypal_address_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/paypal_address_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
   let(:order) { create(:order) }
   let(:original_address) { create(:address) }
-  let(:address) { create(:address) }
+  let(:address) { create(:address, name_attributes) }
   let(:params) {
     {
       updated_address: {
@@ -16,8 +16,8 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
       },
       recipient: {
         name: {
-          given_name: address.firstname,
-          surname: address.lastname
+          given_name: "Alexander",
+          surname: "Hamilton"
         }
       }
     }
@@ -37,8 +37,12 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
       expect(subject.address2).to eq address.address2
       expect(subject.zipcode).to eq address.zipcode
       expect(subject.country).to eq address.country
-      expect(subject.firstname).to eq address.firstname
-      expect(subject.lastname).to eq address.lastname
+      if SolidusSupport.combined_first_and_last_name_in_address?
+        expect(subject.name).to eq address.name
+      else
+        expect(subject.firstname).to eq address.firstname
+        expect(subject.lastname).to eq address.lastname
+      end
       expect(subject.phone).to eq original_address.phone
     end
 
@@ -50,6 +54,14 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
 
         expect(subject).to be_present
       end
+    end
+  end
+
+  def name_attributes
+    if SolidusSupport.combined_first_and_last_name_in_address?
+      { name: "Alexander Hamilton" }
+    else
+      { firstname: "Alexander", lastname: "Hamilton" }
     end
   end
 end

--- a/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request d
 
         get solidus_paypal_commerce_platform.verify_total_path, params: params
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request d
 
         get solidus_paypal_commerce_platform.verify_total_path, params: params
 
-        expect(response).to have_http_status(400)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
 
       expect(payment_method.preferred_client_id).to eq("CLIENT-ID")
       expect(payment_method.preferred_client_secret).to eq("CLIENT-SECRET")
-      expect(response).to have_http_status(201)
+      expect(response).to have_http_status(:created)
     end
   end
 end


### PR DESCRIPTION
This update bumps solidus_support to 0.8 so we can use the address
name helper method. It will also conditionally use firstname/lastname
or name depending on which version fo Solidus you are on - which in
this case only matters for the purposes of `paypal_address`.