### PR TITLE
Wizard#logo use `image_path` over `image_url`.

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/wizard.rb
+++ b/app/models/solidus_paypal_commerce_platform/wizard.rb
@@ -34,7 +34,7 @@ module SolidusPaypalCommercePlatform
     private
 
     def logo
-      ActionController::Base.helpers.image_url(::Spree::Config[:admin_interface_logo])
+      ActionController::Base.helpers.image_path(::Spree::Config[:admin_interface_logo])
     end
   end
 end


### PR DESCRIPTION
- `image_path` computes the asset path including configured asset host
  and digest. This fixes an issue where compiled assets and assets
  stored in a CDN where not referenced correctly.