### PR TITLE
Add Venmo as payment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ With product and cart page checkout, the user is directed to the checkout confir
 
 PayPals API does not allow for admin-side payments. Instead, backend users taking payments for customers will need to use the PayPal Virtual Terminal to take payments. [More info is available on the PayPal website.](https://www.paypal.com/merchantapps/appcenter/acceptpayments/virtualterminal?locale.x=en_US)
 
+## Venmo
+Venmo is currently available to US merchants and buyers. There are also other [prequisites](https://developer.paypal.com/docs/business/checkout/pay-with-venmo/#eligibility).
+
+If the transaction supports Venmo then a button should appear for it on checkout, cart and product page, depending on your `Payment Method` preferences.
+
+If you wish to disable Venmo, then set your `Payment Methods`'s `enable_venmo` preference to `false`. See more about preferences([Configuration](#configuration)) below.
+
+## Configuration
+The easiest way to change the `Payment Method`'s preferences is through admin: `Settings > Payments > "PayPal Commerce Platform" > Edit`.
+
+See more about preferences [here](https://guides.solidus.io/developers/preferences/add-model-preferences.html#access-your-preferences)/
+
 ## Development
 
 ### Testing the extension

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ If the transaction supports Venmo then a button should appear for it on checkout
 
 If you wish to disable Venmo, then set your `Payment Methods`'s `enable_venmo` preference to `false`. See more about preferences([Configuration](#configuration)) below.
 
+[_As Venmo is only available in the US, you may want to mock your location for testing_](#mocking-your-buyer-country)
+
 ## Configuration
 The easiest way to change the `Payment Method`'s preferences is through admin: `Settings > Payments > "PayPal Commerce Platform" > Edit`.
 
@@ -173,6 +175,12 @@ $ bin/rails server
 * Listening on tcp://127.0.0.1:3000
 Use Ctrl-C to stop
 ```
+
+### Mocking your buyer country
+PayPal normally looks at your IP geolocation to see where you are located to determine what funding sources are available to you. For example, Venmo is currently only available to US buyers.
+Because of this, you may want to pretend you are from US check that that Venmo is correctly integrated for these customers. To do this, set the payment method's preference of `force_buyer_country` to "US". See more information about preferences above.
+
+This preference has no effect on production.
 
 ### Updating the changelog
 

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -12,6 +12,7 @@ module SolidusPaypalCommercePlatform
     preference :display_on_cart, :boolean, default: true
     preference :display_on_product_page, :boolean, default: true
     preference :display_credit_messaging, :boolean, default: true
+    preference :enable_venmo, :boolean, default: true
 
     def partial_name
       "paypal_commerce_platform"
@@ -73,6 +74,8 @@ module SolidusPaypalCommercePlatform
       }
 
       parameters[:shipping_preference] = 'NO_SHIPPING' if step_names.exclude? 'delivery'
+      parameters['enable-funding'] = 'venmo' if options[:enable_venmo]
+      parameters['disable-funding'] = 'venmo' unless options[:enable_venmo]
 
       "https://www.paypal.com/sdk/js?#{parameters.to_query}"
     end

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -13,6 +13,7 @@ module SolidusPaypalCommercePlatform
     preference :display_on_product_page, :boolean, default: true
     preference :display_credit_messaging, :boolean, default: true
     preference :enable_venmo, :boolean, default: true
+    preference :force_buyer_country, :string
 
     def partial_name
       "paypal_commerce_platform"
@@ -76,6 +77,10 @@ module SolidusPaypalCommercePlatform
       parameters[:shipping_preference] = 'NO_SHIPPING' if step_names.exclude? 'delivery'
       parameters['enable-funding'] = 'venmo' if options[:enable_venmo]
       parameters['disable-funding'] = 'venmo' unless options[:enable_venmo]
+
+      if !Rails.env.production? && options[:force_buyer_country].present?
+        parameters['buyer-country'] = options[:force_buyer_country]
+      end
 
       "https://www.paypal.com/sdk/js?#{parameters.to_query}"
     end

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -113,6 +113,30 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
         expect(url.query.split("&")).to include("components=buttons")
       end
     end
+
+    context 'when enable_venmo is false' do
+      before { paypal_payment_method.preferences.update(enable_venmo: false) }
+
+      it 'does not include "enable-funding=venmo" as a parameter' do
+        expect(url.query.split('&')).not_to include('enable-funding=venmo')
+      end
+
+      it 'includes "disable-funding=venmo" as a parameter' do
+        expect(url.query.split('&')).to include('disable-funding=venmo')
+      end
+    end
+
+    context 'when enable_venmo is true' do
+      before { paypal_payment_method.preferences.update(enable_venmo: true) }
+
+      it 'includes "enable-funding=venmo" as a parameter' do
+        expect(url.query.split('&')).to include('enable-funding=venmo')
+      end
+
+      it 'does not include "disable-funding=venmo" as a parameter' do
+        expect(url.query.split('&')).not_to include('disable-funding=venmo')
+      end
+    end
   end
 
   private

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -137,6 +137,31 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
         expect(url.query.split('&')).not_to include('disable-funding=venmo')
       end
     end
+
+    context 'when force_buyer_country is an empty string' do
+      it 'does not include the "buyer-country" parameter' do
+        expect(url.query.split('&')).not_to include(match 'buyer-country')
+      end
+    end
+
+    context 'when force_buyer_country is "US"' do
+      before { paypal_payment_method.preferences.update(force_buyer_country: 'US') }
+
+      it 'includes "buyer-country=US" as a parameter' do
+        expect(url.query.split('&')).to include('buyer-country=US')
+      end
+    end
+
+    context 'when force_buyer_country is "US" but the environment is production' do
+      before {
+        allow(Rails.env).to receive(:production?).and_return(true)
+        paypal_payment_method.preferences.update(force_buyer_country: 'US')
+      }
+
+      it 'includes "buyer-country=US" as a parameter' do
+        expect(url.query.split('&')).not_to include(match 'buyer-country')
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Resolves issues/tickets:
- https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/issues/136
- https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/issues/137

Setting the preference enable_venmo to true will now show a Venmo button
on checkout for customers whom it is available to.

For testing purposes, the string preference force_buyer_country was
added. You can use this to mock what country the buyer is from, allowing
you to see what funding sources are shown to customers in various
countries.

This preference does not affect checkout on production, environment.
Instead, PayPal will get this information from their ip geolocation.

More information:
https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#buyer-country