### PR TITLE
Require MFA for RubyGems actions

### DIFF
--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_paypal_commerce_platform'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/releases'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 


### PR DESCRIPTION
This setting tells RubyGems that MFA is required for accounts to be able
perform any of these privileged operations:
- gem push
- gem yank
- gem owner --add/remove
- adding or removing owners using the gem ownership page

This helps make the gem more secure, as users can be more confident
that gem updates were pushed by maintainers.

More information:
https://guides.rubygems.org/mfa-requirement-opt-in/
https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiremfa