### PR TITLE
Replace OpenStruct

### DIFF
--- a/lib/solidus_paypal_commerce_platform/client.rb
+++ b/lib/solidus_paypal_commerce_platform/client.rb
@@ -13,6 +13,8 @@ module SolidusPaypalCommercePlatform
       request.headers["PayPal-Partner-Attribution-Id"] = SolidusPaypalCommercePlatform.config.partner_code
     }.freeze
 
+    Response = Struct.new(:status_code, :error)
+
     attr_reader :environment
 
     def initialize(client_id:, client_secret: "", test_mode: nil)
@@ -29,7 +31,7 @@ module SolidusPaypalCommercePlatform
       @paypal_client.execute(request)
     rescue PayPalHttp::HttpError => e
       Rails.logger.error e.result
-      OpenStruct.new(status_code: 422, error: e.result)
+      Response.new(status_code: 422, error: e.result)
     end
 
     def execute_with_response(request, success_message: nil, failure_message: nil)

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Checkout" do
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }
-    let(:failed_response) { OpenStruct.new(status_code: 500) }
+    let(:failed_response) { instance_double('response', status_code: 500) }
 
     before do
       user = create(:user)

--- a/spec/models/solidus_paypal_commerce_platform/payment_source_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_source_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentSource, type: :model do
   before do
     allow_any_instance_of(SolidusPaypalCommercePlatform::Client).to receive(:execute) do |_client, request|
       expect(request).to be_a(SolidusPaypalCommercePlatform::Gateway::OrdersGetRequest) # rubocop:disable RSpec/ExpectInHook
-      OpenStruct.new(result: OpenStruct.new(status: paypal_order_status))
+      instance_double(
+        'response',
+        result: instance_double('result', status: paypal_order_status)
+      )
     end
   end
 

--- a/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
@@ -18,13 +18,23 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
       expect_any_instance_of(SolidusPaypalCommercePlatform::Client).to receive(:execute) do |_client, request|
         case request
         when SolidusPaypalCommercePlatform::AccessTokenAuthorizationRequest
-          OpenStruct.new(result: OpenStruct.new(access_token: "ACCESS-TOKEN"))
+          instance_double(
+            'response',
+            result: instance_double(
+              'result',
+              access_token: "ACCESS-TOKEN"
+            )
+          )
         when SolidusPaypalCommercePlatform::FetchMerchantCredentialsRequest
           expect(request.headers.fetch("Authorization")).to eq("Bearer ACCESS-TOKEN")
-          OpenStruct.new(result: OpenStruct.new(
-            client_id: "CLIENT-ID",
-            client_secret: "CLIENT-SECRET",
-          ))
+          instance_double(
+            'response',
+            result: instance_double(
+              'result',
+              client_id: "CLIENT-ID",
+              client_secret: "CLIENT-SECRET",
+            )
+          )
         else
           raise "unexpected request: #{request}"
         end


### PR DESCRIPTION
OpenStruct has now become officially discouraged due to:
- performance;
- version compatibility; and
- potential security issues.

More information:
https://docs.ruby-lang.org/en/3.0.0/OpenStruct.html#class-OpenStruct-label-Caveats
https://docs.rubocop.org/rubocop/cops_style.html#styleopenstructuse