### PR TITLE
Allow enable_venmo preference to have default Venmo behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,14 @@ Venmo is currently available to US merchants and buyers. There are also other [p
 
 If the transaction supports Venmo then a button should appear for it on checkout, cart and product page, depending on your `Payment Method` preferences.
 
-If you wish to disable Venmo, then set your `Payment Methods`'s `enable_venmo` preference to `false`. See more about preferences([Configuration](#configuration)) below.
+By default, the extension and PayPal will try to render a Venmo button to buyers when prequisites are met.
+
+Set the PaypalCommercePlatform `PaymentMethod` `venmo_control` preference to:
+- `enforced`, disregard buyer's location and show button (if other prequisites are met); or
+- `enabled` (default), available as a PayPal funding option (if other prequisites are met); or
+- `disabled`, disable Venmo as a funding option.
+
+See more about preferences([Configuration](#configuration)) below.
 
 [_As Venmo is only available in the US, you may want to mock your location for testing_](#mocking-your-buyer-country)
 

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -12,8 +12,13 @@ module SolidusPaypalCommercePlatform
     preference :display_on_cart, :boolean, default: true
     preference :display_on_product_page, :boolean, default: true
     preference :display_credit_messaging, :boolean, default: true
-    preference :enable_venmo, :boolean, default: true
+    preference :venmo_control, :string, default: 'enabled'
     preference :force_buyer_country, :string
+
+    validates :preferred_venmo_control, inclusion: {
+      in: %w[enforced enabled disabled],
+      message: "must be 'enforced', 'enabled' or 'disabled'."
+    }
 
     def partial_name
       "paypal_commerce_platform"
@@ -75,8 +80,8 @@ module SolidusPaypalCommercePlatform
       }
 
       parameters[:shipping_preference] = 'NO_SHIPPING' if step_names.exclude? 'delivery'
-      parameters['enable-funding'] = 'venmo' if options[:enable_venmo]
-      parameters['disable-funding'] = 'venmo' unless options[:enable_venmo]
+      parameters['enable-funding'] = 'venmo' if options[:venmo_control] == 'enforced'
+      parameters['disable-funding'] = 'venmo' if options[:venmo_control] == 'disabled'
 
       if !Rails.env.production? && options[:force_buyer_country].present?
         parameters['buyer-country'] = options[:force_buyer_country]


### PR DESCRIPTION
Before the developer only had two options of:
- disable venmo, enable_venmo: false
- enforce Venmo to be rendered, enable_venmo: true

These changes make so the preference has the option of "enabled",
"disabled" and "default", to allow more control over Venmo.

"default" will let PayPal to decide its availability, by not sending
Venmo as a value on "enable-funding" and "disable-funding" parameters.

More details:
https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#disable-funding
https://developer.paypal.com/docs/business/javascript-sdk/javascript-sdk-configuration/#enable-funding