### PR TITLE
Fix Rails 7 autoloading issues with SolidusPaypalCommercePlatform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2.1
 
 orbs:
+  browser-tools: circleci/browser-tools@1.1
+
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
   # to change this configuration every time a Solidus version is released
@@ -11,10 +13,12 @@ jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   lint-code:
     executor: solidusio_extensions/sqlite-memory

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ Layout/FirstArgumentIndentation:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Naming/VariableNumber:
+  # PayPal uses snake_case, we use normal_case ¯\_(ツ)_/¯
+  Enabled: false
+
 # We use this extensively, the alternatives are not viable or desirable.
 RSpec/AnyInstance:
   Enabled: false
@@ -42,10 +46,6 @@ RSpec/NestedGroups:
 RSpec/VerifiedDoubles:
   # Sometimes you really need an "anything" double
   IgnoreSymbolicNames: true
-
-Rspec/Naming/VariableNumber:
-  # PayPal uses snake_case, we use normal_case ¯\_(ツ)_/¯
-  Enabled: false
 
 Style/FrozenStringLiteralComment:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 # Needed to help Bundler figure out how to resolve dependencies,
 # otherwise it takes forever to resolve them.
 # See https://github.com/bundler/bundler/issues/6677
-gem 'rails', '>0.a'
+gem 'rails', ENV.fetch('RAILS_VERSION', '>0.a')
 
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', ENV.fetch('RAILS_VERSION', '>0.a')
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-case ENV['DB']
+case ENV.fetch('DB', nil)
 when 'mysql'
   gem 'mysql2'
 when 'postgresql'

--- a/bin/rails-engine
+++ b/bin/rails-engine
@@ -7,7 +7,7 @@ ENGINE_PATH = File.expand_path('../lib/solidus_paypal_commerce_platform/engine',
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV.fetch('BUNDLE_GEMFILE', nil))
 
 require 'rails/all'
 require 'rails/engine/commands'

--- a/lib/solidus_paypal_commerce_platform/configuration.rb
+++ b/lib/solidus_paypal_commerce_platform/configuration.rb
@@ -60,11 +60,11 @@ module SolidusPaypalCommercePlatform
     end
 
     def partner_id
-      @partner_id ||= ENV['PAYPAL_PARTNER_ID'] || DEFAULT_PARTNER_ID[env.to_sym]
+      @partner_id ||= ENV.fetch('PAYPAL_PARTNER_ID') { DEFAULT_PARTNER_ID[env.to_sym] }
     end
 
     def partner_client_id
-      @partner_client_id ||= ENV['PAYPAL_PARTNER_CLIENT_ID'] || DEFAULT_PARTNER_CLIENT_ID[env.to_sym]
+      @partner_client_id ||= ENV.fetch('PAYPAL_PARTNER_CLIENT_ID') { DEFAULT_PARTNER_CLIENT_ID[env.to_sym] }
     end
 
     def partner_code

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -18,7 +18,7 @@ module SolidusPaypalCommercePlatform
       app.config.to_prepare do
         app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
         SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
-        Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id,
+        ::Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id,
                                                              :paypal_email, :paypal_funding_source]
       end
     end

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -15,10 +15,12 @@ module SolidusPaypalCommercePlatform
     engine_name 'solidus_paypal_commerce_platform'
 
     initializer "solidus_paypal_commerce_platform.add_payment_method", after: "spree.register.payment_methods" do |app|
-      app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
-      SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
-      Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id,
-                                                           :paypal_email, :paypal_funding_source]
+      app.config.to_prepare do
+        app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
+        SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
+        Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id,
+                                                             :paypal_email, :paypal_funding_source]
+      end
     end
 
     initializer "solidus_paypal_commerce_platform.add_wizard", after: "spree.register.payment_methods" do |app|

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -22,8 +22,9 @@ module SolidusPaypalCommercePlatform
           SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
         end
 
-        ::Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id,
-                                                             :paypal_email, :paypal_funding_source]
+        old_source_attributes = ::Spree::PermittedAttributes.source_attributes
+        new_source_attributes = [:paypal_order_id, :authorization_id, :paypal_email, :paypal_funding_source]
+        ::Spree::PermittedAttributes.source_attributes.concat(new_source_attributes - old_source_attributes)
       end
     end
 

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -17,7 +17,11 @@ module SolidusPaypalCommercePlatform
     initializer "solidus_paypal_commerce_platform.add_payment_method", after: "spree.register.payment_methods" do |app|
       app.config.to_prepare do
         app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
-        SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
+
+        unless SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types.include?(:paypal_select)
+          SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
+        end
+
         ::Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id,
                                                              :paypal_email, :paypal_funding_source]
       end

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Checkout" do
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }
-    let(:failed_response) { instance_double(response, status_code: 500) }
+    let(:failed_response) { double('response', status_code: 500) } # rubocop:disable RSpec/VerifiedDoubles
 
     before do
       user = create(:user)

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Checkout" do
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }
-    let(:failed_response) { instance_double('response', status_code: 500) }
+    let(:failed_response) { instance_double(response, status_code: 500) }
 
     before do
       user = create(:user)

--- a/spec/models/solidus_paypal_commerce_platform/payment_source_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_source_spec.rb
@@ -21,10 +21,13 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentSource, type: :model do
   before do
     allow_any_instance_of(SolidusPaypalCommercePlatform::Client).to receive(:execute) do |_client, request|
       expect(request).to be_a(SolidusPaypalCommercePlatform::Gateway::OrdersGetRequest) # rubocop:disable RSpec/ExpectInHook
-      instance_double(
-        response,
-        result: instance_double(result, status: paypal_order_status)
+
+      # rubocop:disable RSpec/VerifiedDoubles
+      double(
+        'response',
+        result: double('result', status: paypal_order_status)
       )
+      # rubocop:enable RSpec/VerifiedDoubles
     end
   end
 

--- a/spec/models/solidus_paypal_commerce_platform/payment_source_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_source_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentSource, type: :model do
     allow_any_instance_of(SolidusPaypalCommercePlatform::Client).to receive(:execute) do |_client, request|
       expect(request).to be_a(SolidusPaypalCommercePlatform::Gateway::OrdersGetRequest) # rubocop:disable RSpec/ExpectInHook
       instance_double(
-        'response',
-        result: instance_double('result', status: paypal_order_status)
+        response,
+        result: instance_double(result, status: paypal_order_status)
       )
     end
   end

--- a/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
         case request
         when SolidusPaypalCommercePlatform::AccessTokenAuthorizationRequest
           instance_double(
-            'response',
+            response,
             result: instance_double(
-              'result',
+              result,
               access_token: "ACCESS-TOKEN"
             )
           )
         when SolidusPaypalCommercePlatform::FetchMerchantCredentialsRequest
           expect(request.headers.fetch("Authorization")).to eq("Bearer ACCESS-TOKEN")
           instance_double(
-            'response',
+            response,
             result: instance_double(
-              'result',
+              result,
               client_id: "CLIENT-ID",
               client_secret: "CLIENT-SECRET",
             )

--- a/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
@@ -18,23 +18,28 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
       expect_any_instance_of(SolidusPaypalCommercePlatform::Client).to receive(:execute) do |_client, request|
         case request
         when SolidusPaypalCommercePlatform::AccessTokenAuthorizationRequest
-          instance_double(
-            response,
-            result: instance_double(
-              result,
+          # rubocop:disable RSpec/VerifiedDoubles
+          double(
+            'response',
+            result: double(
+              'result',
               access_token: "ACCESS-TOKEN"
             )
           )
+          # rubocop:enable RSpec/VerifiedDoubles
         when SolidusPaypalCommercePlatform::FetchMerchantCredentialsRequest
           expect(request.headers.fetch("Authorization")).to eq("Bearer ACCESS-TOKEN")
-          instance_double(
-            response,
-            result: instance_double(
-              result,
+
+          # rubocop:disable RSpec/VerifiedDoubles
+          double(
+            'response',
+            result: double(
+              'result',
               client_id: "CLIENT-ID",
               client_secret: "CLIENT-SECRET",
             )
           )
+          # rubocop:enable RSpec/VerifiedDoubles
         else
           raise "unexpected request: #{request}"
         end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,5 +7,5 @@ Capybara.register_driver(:cuprite) do |app|
   # to debug the browser status.
   #
   # See also: https://github.com/rubycdp/cuprite#debugging
-  Capybara::Cuprite::Driver.new(app, window_size: [1920, 1080], inspector: ENV["INSPECTOR"])
+  Capybara::Cuprite::Driver.new(app, window_size: [1920, 1080], inspector: ENV.fetch("INSPECTOR", nil))
 end


### PR DESCRIPTION
## Steps to reproduce

1. Create a fresh Rails 7 app.
1. Install Solidus master in the app.
1. Run `rails g solidus:install`.
1. Choose PayPal as the payment method.

## Expected result

The installation process should complete.

## Actual result

The following error is returned:

```
/home/gsmendoza/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/solidus_paypal_commerce_platform-0.3.2/lib/solidus_paypal_commerce_platform/engine.rb:18:
in `block in <class:Engine>': uninitialized constant SolidusPaypalCommercePlatform::PaymentMethod (NameError)
```

## Preliminary changes

In order for this PR to pass CI, I have also fixed existing RuboCop offenses in the codebase.

## Known issues

When I run `bundle exec rake` locally, I get the following error:

```
An error occurred in a `before(:suite)` hook.
Failure/Error: //= link spree/backend/all.js

Sprockets::FileNotFound:
  couldn't find file 'spree/backend/all.js'
  Checked in these paths: 
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/config
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/images
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/stylesheets
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/javascripts
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/stylesheets
```

However, `bundle exec rake` runs fine in CI.

I'm able to work around this issue locally by running `bundle exec rspec` instead.

Since this issue doesn't break CI, I'll investigate it separately.

## Next steps

We'll need to release a bumped version of SolidusPaypalCommercePlatform with this fix in order for `solidus:install` to pick up this change.