### PR TITLE
`bundle exec rake` should be able to find frontend and backend assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-# Needed to help Bundler figure out how to resolve dependencies,
-# otherwise it takes forever to resolve them.
-# See https://github.com/bundler/bundler/issues/6677
-gem 'rails', ENV.fetch('RAILS_VERSION', '>0.a')
+gem 'rails', ENV.fetch('RAILS_VERSION', nil)
 
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 require 'solidus_dev_support/rake_tasks'
+
+# Take note that `SolidusDevSupport::RakeTasks.install` automatically invokes
+# the `extension:test_app` rake task (see the `install_test_app_task` method).
+# Eventually, `extension:test_app` calls the
+# `Solidus::InstallGenerator#setup_assets` method. We need to load
+# `Spree::Frontend` and `Spree::Backend` in order to tell `setup_assets` to
+# install the corresponding assets of these two Solidus components.
+require 'spree/frontend'
+require 'spree/backend'
 SolidusDevSupport::RakeTasks.install
 
 task default: 'extension:specs'

--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   files = Dir.chdir(__dir__) { `git ls-files -z`.split("\x0") }
 
   spec.files = files.grep_v(%r{^(test|spec|features)/})
-  spec.test_files = files.grep(%r{^(test|spec|features)/})
   spec.bindir = "exe"
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
## Dependencies

This depends on https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/pull/156.

Expected behavior
-----------------

Given I have a local clone of the SolidusPaypalCommercePlatform repo
When I run `bundle exec rake` 
Then I expect the specs to run and pass

Actual behavior
---------------

`bundle exec rake` encounters the following error:

```
An error occurred in a `before(:suite)` hook.
Failure/Error: //= link spree/backend/all.js

Sprockets::FileNotFound:
  couldn't find file 'spree/backend/all.js'
  Checked in these paths: 
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/config
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/images
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/spec/dummy/app/assets/stylesheets
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/javascripts
    /home/gsmendoza/repos/solidusio-contrib/solidus_paypal_commerce_platform/app/assets/stylesheets
```

Cause
-----

`bundle exec rake` calls the tasks and methods below in the given order:

* `SolidusDevSupport::RakeTasks.install` 
* `SolidusDevSupport::RakeTasks.install_test_app_task` 
* The `extension:test_app rake task` (this is automatically invoked while the
  tasks are being installed!!!)
* `Solidus::InstallGenerator#setup_assets `

The `setup_assets` method would only install the `all.*` frontend and backend
assets if either

* `Spree::Frontend` and `Spree::Backend` are loaded, or
* The Rails environment is test.

Currently, when we run `bundle exec rake`, neither condition is met:

* `Spree::Frontend` and `Spree::Backend` are NOT loaded.
* The Rails environment is development.

`bundle exec rake` in CI doesn't have this issue because its postgres and mysql
executors set the Rails environment to test.

`bundle exec rspec` also doesn't have this issue, since the `spec_helper.rb`
file sets the Rails environment to test before calling `system 'bin/rake
extension:test_app'`.

Solution
--------

Load the `Spree::Frontend` and `Spree::Backend` classes before calling
`SolidusDevSupport::RakeTasks.install`. 

